### PR TITLE
Added configurable delay to server response.

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1,18 +1,44 @@
 const express = require('express');
 const fakeMovieList = require('./fakeMovieList');
+const { toBoolean, toInt } = require('./stringUtils');
 const app = express();
 const port = process.env.PORT || 5000;
 
+function getDelay(queryObj) {
+  const { minDelay, maxDelay, instant } = queryObj;
+  if (toBoolean(instant)) return 0;
+  return Math.floor(Math.random() * toInt(maxDelay, 2000)) + toInt(minDelay, 200);
+}
+
 app.get('/search/:keyword', (req, res) => {
   const { keyword } = req.params;
+  const delay = getDelay(req.query);
+  const keywordLowerCase = keyword.toLowerCase();
   const matchMovieList = fakeMovieList.filter(
-    movie => movie.title.toLowerCase().indexOf(keyword.toLowerCase()) !== -1
+    movie => movie.title.toLowerCase().indexOf(keywordLowerCase) !== -1
   );
   res.set({
     'Access-Control-Allow-Origin': '*',
   });
-  res.json(matchMovieList);
+  const timerId = setTimeout(() => {
+    res.json(matchMovieList);
+  }, delay);
+
+  handleCancelledRequest(req, res, timerId);
 });
+
+function handleCancelledRequest(req, res, timerId) {
+  req.on('aborted', requestCancelled);
+  req.on('close', requestCancelled);
+
+  function requestCancelled() {
+    clearTimeout(timerId);
+    res.end();
+    // just to fully clean up
+    req.off('aborted', requestCancelled);
+    req.off('close', requestCancelled);
+  }
+}
 
 app.listen(port, (error) => {
   if (error) {

--- a/src/stringUtils.js
+++ b/src/stringUtils.js
@@ -1,0 +1,21 @@
+function stringToBoolean(str) {
+  switch ((str || '').toLowerCase()) {
+    case 'yes':
+    case 'y':
+    case '1':
+    case 'true':
+    case 't':
+      return true;
+    default:
+    return false;
+  }
+}
+
+function stringToInteger(str, defaultValue = 0) {
+  return parseInt(str || `${defaultValue}`, 10);
+}
+
+module.exports = {
+  toBoolean: stringToBoolean,
+  toInt: stringToInteger,
+};


### PR DESCRIPTION
## What problem does this solve?

The existing server response is effectively instant, making it difficult to evaluate real-world conditions where server responses can be significantly delayed. This PR adds a random delay, by default between 200ms and 2 seconds, to the server response.

It also adds support for 3 query string parameters to customize this behavior:

1. `minDelay`: the minimum amount of time to wait before responding, in milliseconds. Defaults to `200`.
2. `maxDelay`: the maximum amount of time to wait before responding, in milliseconds. Defaults to `2000`.
3. `instant`: if `true`, `1` or `y`, overrides the delay range and returns the response immediately. Defaults to `false`.

Finally, I added support to properly clean up if the request is canceled/abandoned, in case candidates add support for canceling superseded requests.